### PR TITLE
fix: Lua 5.5 snapshot improvements

### DIFF
--- a/snapshot.c
+++ b/snapshot.c
@@ -204,7 +204,14 @@ readobject(lua_State *L, lua_State *dL, const void *parent, const char *desc) {
 	if(t == LUA_TUSERDATA) {
 		p = lua_touserdata(L, -1);
 	} else if (t == LUA_TSTRING) {
-		p = lua_tostring(L, -1);
+		/* Lua 5.5: external strings (LSTRFIX/LSTRMEM) store content outside
+		   TString, so lua_tostring cannot derive the GC object address.
+		   Use lua_topointer to get the TString* directly. */
+		#if LUA_VERSION_NUM >= 505
+			p = lua_topointer(L, -1);
+		#else
+			p = lua_tostring(L, -1);
+		#endif
 	}
 	else {
 		p = (const void*)lua_topointer(L, -1);
@@ -412,7 +419,7 @@ mark_thread(lua_State *L, lua_State *dL, const void * parent, const char *desc, 
 	lua_pop(L,1);
 }
 
-static void 
+static void
 mark_object(lua_State *L, lua_State *dL, const void * parent, const char *desc, struct snapshot_params* args) {
 	luaL_checkstack(L, LUA_MINSTACK, NULL);
 	int t = lua_type(L, -1);
@@ -464,7 +471,33 @@ gen_table_desc(lua_State *dL, luaL_Buffer *b, const void * parent, const char *d
 	luaL_addchar(b, '\n');
 }
 
-static size_t 
+/* Lua 5.5: Table internals changed -- no lastfree/sizearray, array uses
+   mixed Value+tag layout, and hash parts >= 2^LIMFORLAST have a Limbox. */
+#if LUA_VERSION_NUM >= 505
+
+#ifndef LIMFORLAST
+#define LIMFORLAST    3
+#endif
+
+typedef struct { Node *dummy; Node follows_pNode; } _Limbox_aux;
+
+static size_t
+_table_size(Table* p) {
+	size_t size = sizeof(*p);
+	if (!isdummy(p)) {
+		size += sizenode(p)*sizeof(Node);
+		if (p->lsizenode >= LIMFORLAST) {
+			size += offsetof(_Limbox_aux, follows_pNode);
+		}
+	}
+	if (p->asize > 0)
+		size += p->asize*(sizeof(Value) + 1) + sizeof(unsigned);
+	return size;
+}
+
+#else
+
+static size_t
 _table_size(Table* p) {
 	size_t size = sizeof(*p);
 	size_t tl = (p->lastfree == NULL)?(0):(sizenode(p));
@@ -476,6 +509,22 @@ _table_size(Table* p) {
 	#endif
 	return size;
 }
+
+#endif
+
+/* Lua 5.5: lua_State is allocated as part of LX (with LUA_EXTRASPACE),
+   and sizeof(LX) != sizeof(lua_State) + LUA_EXTRASPACE due to alignment. */
+#if LUA_VERSION_NUM >= 505
+
+static size_t
+_thread_size(struct lua_State* p) {
+	size_t size = sizeof(LX);
+	size += p->nci*sizeof(CallInfo);
+	size += (stacksize(p) + EXTRA_STACK)*sizeof(*p->stack.p);
+	return size;
+}
+
+#else
 
 static size_t
 _thread_size(struct lua_State* p) {
@@ -497,10 +546,13 @@ _thread_size(struct lua_State* p) {
   	return size;
 }
 
+#endif
+
 
 static size_t
 _userdata_size(Udata *p) {
-	#if LUA_VERSION_NUM == 504
+	/* Lua 5.5 uses the same sizeudata(nuvalue, len) macro as 5.4 */
+	#if LUA_VERSION_NUM >= 504
 		int size = sizeudata(p->nuvalue, p->len);
 		return size;
 	#else
@@ -525,6 +577,31 @@ _lfunc_size(LClosure *p) {
     return size;
 }
 
+/* Lua 5.5: s is a TString* (from lua_topointer), and external strings
+   (LSTRFIX/LSTRMEM) need per-kind size calculation.
+   Lua 5.4 and earlier: s is a content pointer (from lua_tostring),
+   need to subtract header offset to get TString*. */
+#if LUA_VERSION_NUM >= 505
+
+static size_t
+_lstring_size(const void* s) {
+	TString* ts = (TString*)s;
+	if (strisshr(ts))
+		return sizestrshr(cast_uint(ts->shrlen));
+	else {
+		switch (ts->shrlen) {
+		case LSTRREG:
+			return offsetof(TString, falloc) + (ts->u.lnglen + 1) * sizeof(char);
+		case LSTRFIX:
+			return offsetof(TString, falloc);
+		default: /* LSTRMEM: content is externally allocated but freed via falloc on GC */
+			return sizeof(TString) + (ts->u.lnglen + 1) * sizeof(char);
+		}
+	}
+}
+
+#else
+
 static size_t
 _lstring_size(const void* s) {
 	if (s == NULL) return 0;
@@ -533,9 +610,10 @@ _lstring_size(const void* s) {
 	#else
 		TString* ts = (TString*)(((char*)s) - sizeof(UTString));
 	#endif
-	size_t size = tsslen(ts);
-	return size;
+	return sizelstring(tsslen(ts));
 }
+
+#endif
 
 static void
 pdesc(lua_State *L, lua_State *dL, int idx, const char * typename) {
@@ -696,7 +774,12 @@ l_obj2addr(lua_State* L) {
 	if(t == LUA_TUSERDATA) {
 		p = lua_touserdata(L, 1);
 	} else if (t == LUA_TSTRING) {
-		p = (void*)lua_tostring(L, 1);
+		/* Lua 5.5: must match readobject's key derivation for strings */
+		#if LUA_VERSION_NUM >= 505
+			p = (void*)lua_topointer(L, 1);
+		#else
+			p = (void*)lua_tostring(L, 1);
+		#endif
 	}
 	else {
 		p = (void*)lua_topointer(L, 1);
@@ -737,8 +820,14 @@ _objectsize(lua_State* L, int value_idx, int map_idx, int max_deep, int cur_deep
 	lua_settable(L, map_idx);
 	switch(t) {
 		case LUA_TSTRING: {
-			key = (void*)lua_tostring(L, value_idx);
-			size = _lstring_size(key);
+			/* Lua 5.5: key is already TString* from lua_topointer above;
+			   earlier versions need lua_tostring for content pointer. */
+			#if LUA_VERSION_NUM >= 505
+				size = _lstring_size(key);
+			#else
+				key = (void*)lua_tostring(L, value_idx);
+				size = _lstring_size(key);
+			#endif
 			*sz_p += size;
 		} break;
 

--- a/snapshot.c
+++ b/snapshot.c
@@ -103,6 +103,40 @@ is_lightcfunction(lua_State *L, int idx) {
 	return 0;
 }
 
+/*
+** lua_touserdata/lua_topointer return the user data area pointer
+** (getudatamem), not the Udata* struct pointer. We need the Udata*
+** to correctly compute userdata size via sizeudata(nuvalue, len).
+*/
+static Udata *
+udata_from_stack(lua_State *L, int idx) {
+#if LUA_VERSION_NUM >= 504
+	TValue *o;
+	#if LUA_VERSION_RELEASE_NUM < 50405
+		if (idx > 0) {
+			o = s2v(L->ci->func + idx);
+		} else {
+			o = s2v(L->top + idx);
+		}
+	#else
+		if (idx > 0) {
+			o = s2v(L->ci->func.p + idx);
+		} else {
+			o = s2v(L->top.p + idx);
+		}
+	#endif
+	return uvalue(o);
+#else
+	TValue *o;
+	if (idx > 0) {
+		o = L->ci->func + idx;
+	} else {
+		o = L->top + idx;
+	}
+	return rawuvalue(o);
+#endif
+}
+
 #endif
 
 #if LUA_VERSION_NUM == 504
@@ -202,7 +236,7 @@ readobject(lua_State *L, lua_State *dL, const void *parent, const char *desc) {
 
 	const void * p = NULL;
 	if(t == LUA_TUSERDATA) {
-		p = lua_touserdata(L, -1);
+		p = udata_from_stack(L, -1);
 	} else if (t == LUA_TSTRING) {
 		/* Lua 5.5: external strings (LSTRFIX/LSTRMEM) store content outside
 		   TString, so lua_tostring cannot derive the GC object address.
@@ -323,6 +357,22 @@ mark_userdata(lua_State *L, lua_State *dL, const void * parent, const char *desc
 		mark_table(L, dL, t, "[metatable]", args);
 	}
 
+	#if LUA_VERSION_NUM >= 504
+	{
+		int n;
+		for (n = 1; lua_getiuservalue(L, -1, n) != LUA_TNONE; n++) {
+			if (!lua_isnil(L, -1)) {
+				char uvdesc[32];
+				snprintf(uvdesc, sizeof(uvdesc), "[uservalue:%d]", n);
+				mark_object(L, dL, t, uvdesc, args);
+			} else {
+				lua_pop(L, 1);
+			}
+		}
+		lua_pop(L, 1); /* pop the LUA_TNONE */
+	}
+	lua_pop(L, 1);
+	#else
 	lua_getuservalue(L,-1);
 	if (lua_isnil(L,-1)) {
 		lua_pop(L,2);
@@ -330,6 +380,7 @@ mark_userdata(lua_State *L, lua_State *dL, const void * parent, const char *desc
 		mark_object(L, dL, t, "[uservalue]", args);
 		lua_pop(L,1);
 	}
+	#endif
 }
 
 static void
@@ -532,15 +583,15 @@ _thread_size(struct lua_State* p) {
   	size += p->nci*sizeof(CallInfo);
 	#ifdef stacksize
 		#if LUA_VERSION_RELEASE_NUM < 50405
-  			size += stacksize(p)*sizeof(*p->stack);
+  			size += (stacksize(p) + EXTRA_STACK)*sizeof(*p->stack);
 		#else
-			size += stacksize(p)*sizeof(*p->stack.p);
+			size += (stacksize(p) + EXTRA_STACK)*sizeof(*p->stack.p);
 		#endif
   	#else
 		#if LUA_VERSION_RELEASE_NUM < 50405
-  			size += p->stacksize*sizeof(*p->stack);
+  			size += (p->stacksize + EXTRA_STACK)*sizeof(*p->stack);
 		#else
-			size += p->stacksize*sizeof(*p->stack.p);
+			size += (p->stacksize + EXTRA_STACK)*sizeof(*p->stack.p);
 		#endif
   	#endif
   	return size;
@@ -772,7 +823,7 @@ l_obj2addr(lua_State* L) {
 	int t = lua_type(L, 1);
 	void * p = NULL;
 	if(t == LUA_TUSERDATA) {
-		p = lua_touserdata(L, 1);
+		p = udata_from_stack(L, 1);
 	} else if (t == LUA_TSTRING) {
 		/* Lua 5.5: must match readobject's key derivation for strings */
 		#if LUA_VERSION_NUM >= 505
@@ -833,6 +884,9 @@ _objectsize(lua_State* L, int value_idx, int map_idx, int max_deep, int cur_deep
 
 		case LUA_TFUNCTION: {
 			if (is_lightcfunction(L, value_idx)) {
+				break; /* light C functions have no GC object */
+			}
+			if (lua_iscfunction(L, value_idx)) {
 				size = _cfunc_size((CClosure*)key);
 			} else {
 				size = _lfunc_size((LClosure*)key);
@@ -842,6 +896,11 @@ _objectsize(lua_State* L, int value_idx, int map_idx, int max_deep, int cur_deep
 
 		case LUA_TTHREAD: {
 			size = _thread_size((struct lua_State*)key);
+			*sz_p += size;
+		} break;
+
+		case LUA_TUSERDATA: {
+			size = _userdata_size(udata_from_stack(L, value_idx));
 			*sz_p += size;
 		} break;
 

--- a/test_size_compare.lua
+++ b/test_size_compare.lua
@@ -1,0 +1,187 @@
+local ss = require "snapshot"
+
+local function fmt(label, size)
+    io.write(string.format("%-50s %8d bytes\n", label, size))
+end
+
+local function section(title)
+    io.write(string.format("\n=== %s ===\n", title))
+end
+
+io.write(string.format("Lua Version: %s\n", _VERSION))
+
+-- ============================================================
+section("Empty Table")
+-- ============================================================
+fmt("empty table {}", ss.objsize({}))
+
+-- ============================================================
+section("Table with array part only")
+-- ============================================================
+local t1 = {1}
+local t2 = {1, 2}
+local t4 = {1, 2, 3, 4}
+local t8 = {1, 2, 3, 4, 5, 6, 7, 8}
+local t16 = {}; for i = 1, 16 do t16[i] = i end
+local t32 = {}; for i = 1, 32 do t32[i] = i end
+local t64 = {}; for i = 1, 64 do t64[i] = i end
+local t128 = {}; for i = 1, 128 do t128[i] = i end
+
+fmt("{1}                  (1 array slot)", ss.objsize(t1))
+fmt("{1,2}                (2 array slots)", ss.objsize(t2))
+fmt("{1,2,3,4}            (4 array slots)", ss.objsize(t4))
+fmt("{1..8}               (8 array slots)", ss.objsize(t8))
+fmt("{1..16}              (16 array slots)", ss.objsize(t16))
+fmt("{1..32}              (32 array slots)", ss.objsize(t32))
+fmt("{1..64}              (64 array slots)", ss.objsize(t64))
+fmt("{1..128}             (128 array slots)", ss.objsize(t128))
+
+-- ============================================================
+section("Table with hash part only")
+-- ============================================================
+local h1 = {a=1}
+local h2 = {a=1, b=2}
+local h4 = {a=1, b=2, c=3, d=4}
+local h8 = {a=1, b=2, c=3, d=4, e=5, f=6, g=7, h=8}
+local h16 = {}; for i = 1, 16 do h16["k"..i] = i end
+local h32 = {}; for i = 1, 32 do h32["k"..i] = i end
+
+fmt("{a=1}                (1 hash entry)", ss.objsize(h1))
+fmt("{a=1,b=2}            (2 hash entries)", ss.objsize(h2))
+fmt("{a=1..d=4}           (4 hash entries)", ss.objsize(h4))
+fmt("{a=1..h=8}           (8 hash entries)", ss.objsize(h8))
+fmt("{k1=1..k16=16}       (16 hash entries)", ss.objsize(h16))
+fmt("{k1=1..k32=32}       (32 hash entries)", ss.objsize(h32))
+
+-- ============================================================
+section("Table with mixed array + hash")
+-- ============================================================
+local m1 = {1, a=1}
+local m2 = {1, 2, 3, 4, a=1, b=2, c=3, d=4}
+
+fmt("{1, a=1}             (1 arr + 1 hash)", ss.objsize(m1))
+fmt("{1..4, a..d=1..4}    (4 arr + 4 hash)", ss.objsize(m2))
+
+-- ============================================================
+section("Table recursive vs non-recursive")
+-- ============================================================
+local parent = {child = {grandchild = {1, 2, 3}}}
+fmt("parent table         (non-recursive)", ss.objsize(parent))
+fmt("parent table         (recursive)", ss.objsize(parent, true))
+
+-- ============================================================
+section("Short strings (interned, <= 40 chars)")
+-- ============================================================
+fmt("\"\"                   (0 chars)", ss.objsize(""))
+fmt("\"a\"                  (1 char)", ss.objsize("a"))
+fmt("\"hello\"              (5 chars)", ss.objsize("hello"))
+fmt("\"helloworld\"         (10 chars)", ss.objsize("helloworld"))
+fmt("\"12345678901234567890\" (20 chars)", ss.objsize("12345678901234567890"))
+fmt("rep('x', 30)         (30 chars)", ss.objsize(string.rep("x", 30)))
+fmt("rep('x', 40)         (40 chars)", ss.objsize(string.rep("x", 40)))
+
+-- ============================================================
+section("Long strings (> 40 chars)")
+-- ============================================================
+fmt("rep('x', 41)         (41 chars)", ss.objsize(string.rep("x", 41)))
+fmt("rep('x', 50)         (50 chars)", ss.objsize(string.rep("x", 50)))
+fmt("rep('x', 100)        (100 chars)", ss.objsize(string.rep("x", 100)))
+fmt("rep('x', 256)        (256 chars)", ss.objsize(string.rep("x", 256)))
+fmt("rep('x', 1000)       (1000 chars)", ss.objsize(string.rep("x", 1000)))
+fmt("rep('x', 10000)      (10000 chars)", ss.objsize(string.rep("x", 10000)))
+
+-- ============================================================
+section("Functions")
+-- ============================================================
+local f0 = load("return 1")
+local up1 = 1
+local f1 = function() return up1 end
+local up2 = 2
+local f2 = function() return up1 + up2 end
+local up3 = 3
+local f3 = function() return up1 + up2 + up3 end
+
+fmt("load('return 1')     (0 upvalues)", ss.objsize(f0))
+fmt("closure              (1 upvalue)", ss.objsize(f1))
+fmt("closure              (2 upvalues)", ss.objsize(f2))
+fmt("closure              (3 upvalues)", ss.objsize(f3))
+local ok, sz = pcall(ss.objsize, print)
+if ok then fmt("print                (C function)", sz)
+else fmt("print                (C function) [unsupported]", 0) end
+ok, sz = pcall(ss.objsize, string.format)
+if ok then fmt("string.format        (C function)", sz)
+else fmt("string.format        (C function) [unsupported]", 0) end
+
+-- ============================================================
+section("Threads (coroutines)")
+-- ============================================================
+local co_empty = coroutine.create(function() end)
+local co_stack = coroutine.create(function()
+    local a, b, c, d, e = 1, 2, 3, 4, 5
+    local t = {a, b, c, d, e}
+    coroutine.yield(t)
+end)
+coroutine.resume(co_stack)
+
+fmt("coroutine (fresh)", ss.objsize(co_empty))
+fmt("coroutine (yielded, with locals)", ss.objsize(co_stack))
+
+-- ============================================================
+section("Snapshot entry sizes (sample)")
+-- ============================================================
+-- Create identifiable objects and check their sizes in snapshot
+local marker_table = {}
+for i = 1, 10 do marker_table[i] = i end
+_G.__size_cmp_table = marker_table
+
+local marker_str = "size_compare_test_string_marker_unique_12345678"
+_G.__size_cmp_str = marker_str
+
+local marker_func = function()
+    local x = marker_table
+    return x
+end
+_G.__size_cmp_func = marker_func
+
+local snap = ss.snapshot()
+
+local marker_table_addr = ss.obj2addr(marker_table)
+local marker_str_addr = ss.obj2addr(marker_str)
+local marker_func_addr = ss.obj2addr(marker_func)
+
+if snap[marker_table_addr] then
+    local _, sz = string.match(snap[marker_table_addr], "^([^{}]+) {(%d+)}")
+    fmt("snapshot: marker table", tonumber(sz))
+    fmt("objsize:  marker table", ss.objsize(marker_table))
+end
+
+if snap[marker_str_addr] then
+    local _, sz = string.match(snap[marker_str_addr], "^([^{}]+) {(%d+)}")
+    fmt("snapshot: marker string (48 chars)", tonumber(sz))
+    fmt("objsize:  marker string (48 chars)", ss.objsize(marker_str))
+end
+
+if snap[marker_func_addr] then
+    local _, sz = string.match(snap[marker_func_addr], "^([^{}]+) {(%d+)}")
+    fmt("snapshot: marker function", tonumber(sz))
+    fmt("objsize:  marker function", ss.objsize(marker_func))
+end
+
+-- Count total snapshot memory
+local total_objects = 0
+local total_size = 0
+for k, v in pairs(snap) do
+    total_objects = total_objects + 1
+    local _, sz = string.match(v, "^([^{}]+) {(%d+)}")
+    if sz then
+        total_size = total_size + tonumber(sz)
+    end
+end
+fmt("snapshot: total objects", total_objects)
+fmt("snapshot: total size", total_size)
+
+_G.__size_cmp_table = nil
+_G.__size_cmp_str = nil
+_G.__size_cmp_func = nil
+
+io.write("\nDone.\n")


### PR DESCRIPTION
### 概述

本 PR 为 lua-snapshot 添加 Lua 5.5 支持，并修复了多个对象大小计算中的长期 bug（部分同样影响 5.4）。

### Bug 修复

#### 1. Lua 5.5 兼容性适配
- **Table 大小**：适配 Lua 5.5 新的 `Table` 布局（Limbox 机制、`LIMFORLAST` 宏、移除 `lastfree`/`lsizenode`）
- **字符串大小**：处理 Lua 5.5 外部字符串类型（`LSTRFIX`、`LSTRMEM`），修复 5.4 中 `_lstring_size` 漏算头部的问题
- **线程大小**：支持 5.4.5+/5.5 中 `StkIdRel` 栈指针变更
- **字符串 key 获取**：5.5 中改用 `lua_topointer` 替代 `lua_tostring`（外部字符串内容存储在 `TString` 外部）

#### 2. `mark_userdata`：支持多个 uservalue（Lua 5.4+）
- 之前只处理 1 个 uservalue，现在通过 `lua_getiuservalue` 循环遍历所有 uservalue

#### 3. `_objectsize`：补充缺失的 `LUA_TUSERDATA` 分支
- userdata 对象之前在 `objsize()` 计算中被静默忽略

#### 4. `_objectsize`：修复函数类型判断
- light C function（无 upvalue）现在正确返回 0，不再读取垃圾内存
- C closure 正确使用 `_cfunc_size`，Lua closure 使用 `_lfunc_size`

#### 5. `_thread_size`：5.4 分支补充 `EXTRA_STACK`
- Lua 实际分配 `stacksize + EXTRA_STACK` 个栈槽，大小计算必须包含这部分

#### 6. 修复 userdata 地址获取错误（origin/master 就有的 bug，影响 5.3+）
- `lua_touserdata`/`lua_topointer` 返回的是**用户数据区指针**（`getudatamem`），不是 `Udata*` 结构体指针
- `pdesc` 和 `_objectsize` 将此指针强转为 `Udata*` 读取 `nuvalue`/`len` 字段，得到**垃圾值**
- 新增 `udata_from_stack()` 辅助函数，通过内部宏 `s2v`/`uvalue` 从栈上获取正确的 `Udata*`（支持 Lua 5.3~5.5）
- **修复前**：IO userdata 报告 924,200 字节（5.5）/ 256,760 字节（5.4）；snapshot 总大小溢出至 ~2GB
- **修复后**：IO userdata 正确报告 48 字节；snapshot 总大小 ~25KB

### 测试

- Lua 5.4.7 和 Lua 5.5.0 双版本 **54/54 测试全部通过**
- 新增 `test_size_compare.lua` 用于跨版本大小对比
- 验证 `snapshot()` 和 `objsize()` 结果一致
- 验证 snapshot 总大小合理（5.5 约 25KB，5.4 约 29KB）

### 变更文件

- `snapshot.c` — 所有 bug 修复和 Lua 5.5 兼容性适配
- `test_size_compare.lua` — 新增跨版本大小对比测试脚本