### PR TITLE
fix: accurate thread size for Lua 5.4 + flexible objsize depth control

### DIFF
--- a/snapshot.c
+++ b/snapshot.c
@@ -579,7 +579,7 @@ _thread_size(struct lua_State* p) {
 
 static size_t
 _thread_size(struct lua_State* p) {
-	size_t size = sizeof(*p);
+	size_t size = sizeof(*p) + LUA_EXTRASPACE;
   	size += p->nci*sizeof(CallInfo);
 	#ifdef stacksize
 		#if LUA_VERSION_RELEASE_NUM < 50405
@@ -923,9 +923,13 @@ static int
 l_objsize(lua_State* L) {
 	lua_newtable(L);
 	int map_idx = lua_gettop(L);
-	bool recursive = lua_toboolean(L, 2);
 	size_t sz = 0;
-	int max_deep = (recursive)?(128):(0);
+	int max_deep;
+	if (lua_isinteger(L, 2)) {
+		max_deep = (int)lua_tointeger(L, 2);
+	} else {
+		max_deep = lua_toboolean(L, 2) ? 128 : 0;
+	}
 	_objectsize(L, 1, map_idx, max_deep, 0, &sz);
 	lua_pushinteger(L, sz);
 	return 1;


### PR DESCRIPTION
## 改动

### 1. 修复 Lua 5.4 分支 `_thread_size` 少算 LUA_EXTRASPACE 的问题

Lua 5.4 分支的 `_thread_size` 使用 `sizeof(*p)`（即 `sizeof(lua_State)`），
但实际分配的大小是 `sizeof(LX)`。

以下是 Lua 官方源码（lstate.c）中的相关实现：

```c
// Lua 源码 lstate.c:35-38 — LX 在 lua_State 前面包含了 LUA_EXTRASPACE
typedef struct LX {
  lu_byte extra_[LUA_EXTRASPACE];  // 64 位系统上为 8 字节
  lua_State l;
} LX;

// Lua 源码 lstate.c:293 — 分配时使用 sizeof(LX)
o = luaC_newobjdt(L, LUA_TTHREAD, sizeof(LX), offsetof(LX, l));

// Lua 源码 lstate.c:319 — 释放时同样使用 sizeof(LX)（通过 fromstate() 反推）
luaM_free(L, fromstate(L1));  // 展开为 sizeof(LX)
```

GC 的分配和释放都使用 `sizeof(LX)`，因此 `_thread_size` 也必须包含
`LUA_EXTRASPACE` 才能准确计算。

本仓库的 Lua 5.5 分支已经用了正确的写法（`sizeof(LX)`）。本次修复通过
添加 `+ LUA_EXTRASPACE` 来对齐 Lua 5.4 分支的行为。之所以不直接使用
`sizeof(LX)`，是因为 LX 结构体定义在 Lua 源码 lstate.c 内部，
snapshot.c 无法访问。

### 2. `l_objsize` 支持 integer 类型的 `max_depth` 参数

此前 `l_objsize` 的第 2 个参数只接受 boolean（`true` → 递归 128 层，
`false` → 不递归）。现在同时支持传入 integer 来精确控制递归深度
（例如 `objsize(obj, 3)` 表示递归 3 层）。

完全向后兼容：优先用 `lua_isinteger` 判断是否为整数，不是则 fallback
到原有的 `lua_toboolean` 行为。
